### PR TITLE
chore!: update dev shell to Node 26

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6,11 +6,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1772204473,
-        "narHash": "sha256-iT3F56ad9zxrY7BCjVIyBk8xHwnULL3WcJOdQc+HHVU=",
+        "lastModified": 1780896346,
+        "narHash": "sha256-WC5hQ0GOmFPKrlbit3vjjJMlltwI5vpWXsHj/n5NvVk=",
         "owner": "Kyure-A",
         "repo": "agent-skills-nix",
-        "rev": "9ee599cb979640aa403083106743a3e3f6458645",
+        "rev": "61d701aa8fffd918d8d8c0ac4784bdbadf6ddd60",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     "anthropic-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1771993718,
-        "narHash": "sha256-mZZ0rlj/kju7we1h+MvUjgFAVjcZ/qKkMbNZfhfCSvk=",
+        "lastModified": 1780863693,
+        "narHash": "sha256-szcnow0yO1ViQt6Mxrd+PNdfZ5jzPqqSmqA0jEQnS1o=",
         "owner": "anthropics",
         "repo": "skills",
-        "rev": "3d59511518591fa82e6cfcf0438d68dd5dad3e76",
+        "rev": "c30d329f5814647c1e2f071020c1e8c1c9893ef1",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771756436,
-        "narHash": "sha256-Tl2I0YXdhSTufGqAaD1ySh8x+cvVsEI1mJyJg12lxhI=",
+        "lastModified": 1780885330,
+        "narHash": "sha256-aMA5oAq2Iv467U9s8YOb50DYQT9w0WJbyWqwlzHuLMs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5bd3589390b431a63072868a90c0f24771ff4cbb",
+        "rev": "4fe95527cbe952713318ada8a4d122e1a6ab120f",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
     "next-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1771265179,
-        "narHash": "sha256-YkDZc2hmYukW/ahPsnzc/UHeckVVybjctKDs5MYRvZA=",
+        "lastModified": 1778178722,
+        "narHash": "sha256-w9sdMOFGuDnGULNTaZ8QU92YkvYebevc5Xg+87NHAI0=",
         "owner": "vercel-labs",
         "repo": "next-skills",
-        "rev": "038954e07bfc313e97fa5f6ff7caf87226e4a782",
+        "rev": "dc1de9caf7612d73f56a8dec3cb1bd6c9ec096b9",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771369470,
-        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {
@@ -90,11 +90,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1771848320,
-        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
     "ui-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1771490062,
-        "narHash": "sha256-j5qRM+Cx/6Wetp5rQir9LX6sx1NBNq2tBhcTt0YafJI=",
+        "lastModified": 1779990333,
+        "narHash": "sha256-4n6Ak54cdDNbtfhqCCg8jVBaCdrwH2tKRehz51n4ldc=",
         "owner": "ibelick",
         "repo": "ui-skills",
-        "rev": "66eb2f5bc6c5dbdd13e601e23fb55ea64692807c",
+        "rev": "23f2034ff1a8681fe23a678e4ef5fb82d586c878",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,7 @@
           default = pkgs.mkShell {
             packages = with pkgs; [
               actionlint
-              nodejs_20
+              nodejs_26
               pnpm_9
               biome
               semgrep

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "security:semgrep": "semgrep scan --config p/default --error --metrics=off ."
   },
   "dependencies": {
-    "@js-temporal/polyfill": "^0.5.1",
     "@react-spring/web": "^10.0.3",
     "@vscode/markdown-it-katex": "^1.1.2",
     "budoux": "0.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,9 +16,6 @@ importers:
 
   .:
     dependencies:
-      '@js-temporal/polyfill':
-        specifier: ^0.5.1
-        version: 0.5.1
       '@react-spring/web':
         specifier: ^10.0.3
         version: 10.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -758,10 +755,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@js-temporal/polyfill@0.5.1':
-    resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
-    engines: {node: '>=12'}
 
   '@napi-rs/wasm-runtime@0.2.8':
     resolution: {integrity: sha512-OBlgKdX7gin7OIq4fadsjpg+cp2ZphvAIKucHsNfTdJiqdOmOEwQd/bHi0VwNrcw5xpBJyUw6cK/QilCqy1BSg==}
@@ -2406,9 +2399,6 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  jsbi@4.3.2:
-    resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
-
   jsdom@17.0.0:
     resolution: {integrity: sha512-MUq4XdqwtNurZDVeKScENMPHnkgmdIvMzZ1r1NSwHkDuaqI6BouPjr+17COo4/19oLNnmdpFDPOHVpgIZmZ+VA==}
     engines: {node: '>=12'}
@@ -3924,10 +3914,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@js-temporal/polyfill@0.5.1':
-    dependencies:
-      jsbi: 4.3.2
 
   '@napi-rs/wasm-runtime@0.2.8':
     dependencies:
@@ -5724,8 +5710,6 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
-
-  jsbi@4.3.2: {}
 
   jsdom@17.0.0(canvas@3.2.1):
     dependencies:


### PR DESCRIPTION
## Summary

- update the Nix dev shell from `nodejs_20` to `nodejs_26`
- refresh `flake.lock` so the updated nixpkgs resolves Node.js 26.3.0
- remove the unused `@js-temporal/polyfill` dependency now that Node.js 26 provides `globalThis.Temporal`

## Impact

The project dev shell now starts with Node.js 26 while keeping pnpm pinned to 9.15.9. The Temporal polyfill and its transitive `jsbi` dependency are no longer installed.

## Validation

- `nix develop --command node --version` -> `v26.3.0`
- `nix develop --command pnpm install --frozen-lockfile`
- `nix develop --command pnpm lint`
- `nix develop --command pnpm build`
- `rg -n "@js-temporal/polyfill|Temporal\\.|temporal" . -g '!node_modules'` -> no matches

Note: Node 26 surfaces existing deprecation/runtime warnings from dependencies during install/build, but the commands complete successfully.